### PR TITLE
remove duplicate output key

### DIFF
--- a/cwlfiles/cubical.cwl
+++ b/cwlfiles/cubical.cwl
@@ -2298,11 +2298,7 @@ outputs:
   parmdb_save_out:
     type: File[]
     outputBinding:
-      glob: "*parmdb"
-  parmdb_save_out:
-    type: File[]
-    outputBinding:
-      glob: "*parmdb.skel"
+      glob: "*parmdb*"
   data_ms_out:
     type: Directory
     outputBinding:


### PR DESCRIPTION
I @Athanaseus,

I found an doublicate output key in one of the cwl files. Unfortunately, this does not resolve the issue CompEpigen/CWLab#38. 